### PR TITLE
Fix off-by one error in download range request

### DIFF
--- a/chunk/download.go
+++ b/chunk/download.go
@@ -80,7 +80,7 @@ func downloadFromAPI(client *http.Client, request *Request, delay int64) ([]byte
 		return nil, fmt.Errorf("Could not create request object %v (%v) from API", request.object.ObjectID, request.object.Name)
 	}
 
-	req.Header.Add("Range", fmt.Sprintf("bytes=%v-%v", request.offsetStart, request.offsetEnd))
+	req.Header.Add("Range", fmt.Sprintf("bytes=%v-%v", request.offsetStart, request.offsetEnd-1))
 
 	Log.Tracef("Sending HTTP Request %v", req)
 


### PR DESCRIPTION
A range request for the first 1024 bytes looks like `Range: bytes=0-1023`, but plexdrive currently does `Range: bytes=0-1024`, which means Content-Length will be 1025 Byte or off by one Byte.