### PR TITLE
Fix reads across chunk boundaries

### DIFF
--- a/chunk/manager_test.go
+++ b/chunk/manager_test.go
@@ -1,0 +1,53 @@
+package chunk
+
+import "testing"
+
+func TestSplitChunkRanges(t *testing.T) {
+	testcases := []struct {
+		offset, size, chunkSize int64
+		result                  []byteRange
+	}{
+		{0, 0, 4096, []byteRange{}},
+		{0, 4096, 4096, []byteRange{
+			{0, 4096},
+		}},
+		{4095, 4096, 4096, []byteRange{
+			{4095, 1},
+			{4096, 4095},
+		}},
+		{0, 8192, 4096, []byteRange{
+			{0, 4096},
+			{4096, 4096},
+		}},
+		{2048, 8192, 4096, []byteRange{
+			{2048, 2048},
+			{4096, 4096},
+			{8192, 2048},
+		}},
+		{2048, 8192, 4096, []byteRange{
+			{2048, 2048},
+			{4096, 4096},
+			{8192, 2048},
+		}},
+		{17960960, 16777216, 10485760, []byteRange{
+			{17960960, 3010560},
+			{20971520, 10485760},
+			{31457280, 3280896},
+		}},
+	}
+	for i, tc := range testcases {
+		ranges := splitChunkRanges(tc.offset, tc.size, tc.chunkSize)
+		actualSize := len(ranges)
+		expectedSize := len(tc.result)
+		if actualSize != expectedSize {
+			t.Fatalf("ByteRange %v length mismatch: %v != %v", i, actualSize, expectedSize)
+		}
+		for j, r := range ranges {
+			actual := r
+			expected := tc.result[j]
+			if actual != expected {
+				t.Fatalf("ByteRange %v mismatch: %v != %v", i, actual, expected)
+			}
+		}
+	}
+}

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -232,16 +232,13 @@ func (o *Object) Lookup(ctx context.Context, name string) (fs.Node, error) {
 
 // Read reads some bytes or the whole file
 func (o *Object) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
-	response := make(chan chunk.Response)
-	o.chunkManager.GetChunk(o.object, req.Offset, int64(req.Size), response)
-	res := <-response
-
-	if nil != res.Error {
-		Log.Warningf("%v", res.Error)
+	data, err := o.chunkManager.GetChunk(o.object, req.Offset, int64(req.Size))
+	if nil != err {
+		Log.Warningf("%v", err)
 		return fuse.EIO
 	}
 
-	resp.Data = res.Bytes
+	resp.Data = data
 	return nil
 }
 


### PR DESCRIPTION
When using Direct-IO requests are not guaranteed to be aligned on page
size boundary, like with buffered IO. This means a read request can
start at the end of one chunk and finish at the beginning of the next
chunk. In cases where this happens we now request multiple chunks in
GetChunk and assemble the response data.

This also removed the float conversions in `adjustResponseChunk`.

**IMPORTANT:** Must be merged after #349 to avoid corruption, since we would repeat the off-by-one byte.

ToDos:

- [x] Add unit tests for splitRequestChunks
