### PR TITLE
Add direct_io mount option, max_readahead default

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Feel free to ask configuration and setup questions here.
 * writeback_cache
 * volume_name=myname
 * read_only
-
+* direct_io
 
 ### Root-Node-ID
 You can use the option `root-node-id` to specify a folder id that should be mounted as

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	argChunkLoadAhead := flag.Int("chunk-load-ahead", max(runtime.NumCPU()-1, 1), "The number of chunks that should be read ahead")
 	argMaxChunks := flag.Int("max-chunks", runtime.NumCPU()*2, "The maximum number of chunks to be stored on disk")
 	argRefreshInterval := flag.Duration("refresh-interval", 1*time.Minute, "The time to wait till checking for changes")
-	argMountOptions := flag.StringP("fuse-options", "o", "", "Fuse mount options (e.g. -fuse-options allow_other,...)")
+	argMountOptions := flag.StringP("fuse-options", "o", "", "Fuse mount options (e.g. --fuse-options allow_other,direct_io,...)")
 	argVersion := flag.Bool("version", false, "Displays program's version information")
 	argUID := flag.Int64("uid", -1, "Set the mounts UID (-1 = default permissions)")
 	argGID := flag.Int64("gid", -1, "Set the mounts GID (-1 = default permissions)")


### PR DESCRIPTION
This reduces the number of FUSE read requests significantly by using
a default max_readahead value of 128 KB, which is the default readahead
used by libfuse and also the maximum request size for buffered I/O used
by the FUSE implementation in the Linux kernel.

We need to set a default, because the bazil.org/fuse package otherwise
defaults to max_readahead=0, which disables readahead completely causing
FUSE to request only 4 KB (one page) per request.

The direct_io option allows to force all files to be opened with the
O_DIRECT flag, bypassing kernel cache, I/O reordering and alignment.
Depending on the apps I/O patterns this can be benefitial, because
it avoids double-buffering of data in both the storage chunk cache
and kernel memory leading to reduced memory usage and CPU usage for
moving data in and out of kernel caches.

It will also theoretically allow FUSE requests of up to 1 MB instead
of the maximum of 128 KB, which FUSE enforces for buffered I/O, because
it splits larger requests into multiple 128 KB chunks that it requests
asynchronously.

Currently the maximum with Direct (unbuffered) I/O will still be 128 KB,
because the bazil.org/fuse package does not yet support the required
FUSE version and max_pages capability required for larger I/Os.

**IMPORTANT:** Must be merged after #350 to avoid short reads with unaligned offsets.

ToDo:

- [x] Document direct_io in README