### PR TITLE
Put cache.bolt in config path by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can use [this tutorial](TUTORIAL.md) for instruction how to mount an encrypt
 ```
 Usage of ./plexdrive mount:
   --cache-file string
-    	Path the the cache file (default "~/.plexdrive/cache.bolt")
+    	Path of the cache file (default "~/.plexdrive/cache.bolt")
   --chunk-check-threads int
     	The number of threads to use for checking chunk existence (default 2)
   --chunk-load-ahead int

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	argRootNodeID := flag.String("root-node-id", "root", "The ID of the root node to mount (use this for only mount a sub directory)")
 	argDriveID := flag.String("drive-id", "", "The ID of the shared drive to mount (including team drives)")
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
-	argCacheFile := flag.String("cache-file", filepath.Join(home, ".plexdrive", "cache.bolt"), "Path the the cache file")
+	argCacheFile := flag.String("cache-file", filepath.Join(*argConfigPath, "cache.bolt"), "Path of the cache file")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
 	argChunkCheckThreads := flag.Int("chunk-check-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for checking chunk existence")


### PR DESCRIPTION
Many users change the config path to run multiple copies of plexdrive,
but forget to also set the cache file path, which results in corruption
of the cache.bolt database. This changes the default for the cache file,
so it is located in the config path unless otherwise specified.