### PR TITLE
Fix help description for max-chunks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage of ./plexdrive mount:
   --gid int
     	Set the mounts GID (-1 = default permissions) (default -1)
   --max-chunks int
-    	The maximum number of chunks to be stored on disk (default 10)
+    	The maximum number of chunks to be stored in memory (default 10)
   --refresh-interval duration
     	The time to wait till checking for changes (default 1m0s)
   --root-node-id string

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
 	argChunkCheckThreads := flag.Int("chunk-check-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for checking chunk existence")
 	argChunkLoadAhead := flag.Int("chunk-load-ahead", max(runtime.NumCPU()-1, 1), "The number of chunks that should be read ahead")
-	argMaxChunks := flag.Int("max-chunks", runtime.NumCPU()*2, "The maximum number of chunks to be stored on disk")
+	argMaxChunks := flag.Int("max-chunks", runtime.NumCPU()*2, "The maximum number of chunks to be stored in memory")
 	argRefreshInterval := flag.Duration("refresh-interval", 1*time.Minute, "The time to wait till checking for changes")
 	argMountOptions := flag.StringP("fuse-options", "o", "", "Fuse mount options (e.g. -fuse-options allow_other,...)")
 	argVersion := flag.Bool("version", false, "Displays program's version information")


### PR DESCRIPTION
Fixed description for --max-chunks stating "maximum number of chunks to be stored on disk" when it actually affects "maximum number of chunks to be stored in memory".

According to [Issue#246 ](https://github.com/plexdrive/plexdrive/issues/246) --max-chunks represents chunks stored in memory not on disc. 

This is backed up by my VM running out of memory when I set --max-chunks to be capable of storing 256GB worth of chunks.

Fixed the typo so that others wont make the same config mistakes and have machines crash :)