### PR TITLE
Use RW Lock for Storage, skip duplicate stores

### DIFF
--- a/chunk/stack.go
+++ b/chunk/stack.go
@@ -10,7 +10,7 @@ type Stack struct {
 	items   *list.List
 	index   map[string]*list.Element
 	len     int
-	lock    sync.RWMutex
+	lock    sync.Mutex
 	maxSize int
 }
 

--- a/chunk/storage.go
+++ b/chunk/storage.go
@@ -46,8 +46,8 @@ func (s *Storage) Clear() error {
 func (s *Storage) Load(id string) []byte {
 	s.lock.Lock()
 	if chunk, exists := s.chunks[id]; exists {
-		s.lock.Unlock()
 		s.stack.Touch(id)
+		s.lock.Unlock()
 		return chunk
 	}
 	s.lock.Unlock()
@@ -57,6 +57,12 @@ func (s *Storage) Load(id string) []byte {
 // Store stores a chunk in the RAM and adds it to the disk storage queue
 func (s *Storage) Store(id string, bytes []byte) error {
 	s.lock.Lock()
+
+	if _, exists := s.chunks[id]; exists {
+		s.stack.Touch(id)
+		s.lock.Unlock()
+		return nil
+	}
 
 	deleteID := s.stack.Pop()
 	if "" != deleteID {


### PR DESCRIPTION
This uses an RWMutex on the Storahge so multiple reads can happen in parallel without blocking on each other, while write block everything.

It also skips storing a new chunks if it already exists, which can happen under read lock.

Closes #335 