### PR TITLE
Support Systemd Notify Type

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -20,9 +20,9 @@ AssertPathIsDirectory=/mnt/plexdrive
 After=network-online.target
 
 [Service]
-Type=simple
+Type=notify
 ExecStart=/usr/bin/plexdrive mount -v 2 /mnt/plexdrive
-ExecStop=/bin/fusermount -u /mnt/plexdrive
+ExecStopPost=-/bin/fusermount -quz /mnt/plexdrive
 Restart=on-abort
 
 [Install]

--- a/main.go
+++ b/main.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/claudetech/loggo"
 	. "github.com/claudetech/loggo/default"
+	flag "github.com/ogier/pflag"
 	"github.com/plexdrive/plexdrive/chunk"
 	"github.com/plexdrive/plexdrive/config"
 	"github.com/plexdrive/plexdrive/drive"
 	"github.com/plexdrive/plexdrive/mount"
-	flag "github.com/ogier/pflag"
 	"golang.org/x/sys/unix"
 )
 

--- a/main.go
+++ b/main.go
@@ -205,14 +205,13 @@ func main() {
 
 func checkOsSignals(mountpoint string) {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		for sig := range signals {
-			if sig == syscall.SIGINT {
-				if err := mount.Unmount(mountpoint, false); nil != err {
-					Log.Warningf("%v", err)
-				}
+			Log.Infof("Received signal %v, stopping mount", sig)
+			if err := mount.Unmount(mountpoint, false); nil != err {
+				Log.Warningf("%v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
This adds support for running plexdrive via systemd and `type=notify` which is useful since it allows dependent units to know exactly when the mount is ready so theys don't need to manually wait for it.

I've also added SIGTERM to the unmount sighandler, which caused plexdrive to hang during systemd stop until it received a SIGKILL.

This means that the systemd unit doesn't really need to call `fusermount -u` anymore, so I moved that to an optional post stop command, in case we need to clean up the mount after a crash.

The TUTORIAL.md was updated to show the new config.

