### PR TITLE
Reuse storage buffers

### DIFF
--- a/chunk/storage.go
+++ b/chunk/storage.go
@@ -67,15 +67,21 @@ func (s *Storage) Store(id string, bytes []byte) error {
 	s.lock.RUnlock()
 	s.lock.Lock()
 
+	var chunk []byte
 	deleteID := s.stack.Pop()
 	if "" != deleteID {
+		chunk = s.chunks[deleteID]
 		delete(s.chunks, deleteID)
 
 		Log.Debugf("Deleted chunk %v", deleteID)
+	} else {
+		chunk = make([]byte, s.ChunkSize)
 	}
 
-	s.chunks[id] = bytes
+	copy(chunk, bytes)
+	s.chunks[id] = chunk
 	s.stack.Push(id)
+
 	s.lock.Unlock()
 
 	return nil


### PR DESCRIPTION
This reduces memory pressure since we don't throw away and recreate buffers all the time.

This should've been merged *before* #384, since it depends on the copy-on-store this change adds.