### PR TITLE
Store chunks from downloader to reduce lock contention

### DIFF
--- a/chunk/manager.go
+++ b/chunk/manager.go
@@ -3,8 +3,6 @@ package chunk
 import (
 	"fmt"
 
-	. "github.com/claudetech/loggo/default"
-
 	"github.com/plexdrive/plexdrive/drive"
 )
 
@@ -60,7 +58,9 @@ func NewManager(
 		return nil, fmt.Errorf("max-chunks must be greater than 2 and bigger than the load ahead value")
 	}
 
-	downloader, err := NewDownloader(loadThreads, client, chunkSize)
+	storage := NewStorage(chunkSize, maxChunks)
+
+	downloader, err := NewDownloader(loadThreads, client, storage, chunkSize)
 	if nil != err {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func NewManager(
 		ChunkSize:  chunkSize,
 		LoadAhead:  loadAhead,
 		downloader: downloader,
-		storage:    NewStorage(chunkSize, maxChunks),
+		storage:    storage,
 		queue:      make(chan *QueueEntry, 100),
 	}
 
@@ -212,10 +212,6 @@ func (m *Manager) checkChunk(req *Request, response chan Response) {
 				Sequence: req.sequence,
 				Bytes:    adjustResponseChunk(req, bytes),
 			}
-		}
-
-		if err := m.storage.Store(req.id, bytes); nil != err {
-			Log.Warningf("Coult not store chunk %v", req.id)
 		}
 	})
 }


### PR DESCRIPTION
This avoids trying to store the download buffer over and over again for each callback.

**Example:**

We download Chunk 42 with 8 MB, but we requested multiple ranges, eg. 0-4095, 4096-8191 etc. and each time the callback for range was called we also tried to store the entire chunk again which requires a read lock on the storage (no wirte lock, since it already exists).