### PR TITLE
Add support for --acknowledge-abuse flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,38 +35,23 @@ You can use [this tutorial](TUTORIAL.md) for instruction how to mount an encrypt
 ## Usage
 ```
 Usage of ./plexdrive mount:
-  --cache-file string
-    	Path of the cache file (default "~/.plexdrive/cache.bolt")
-  --chunk-check-threads int
-    	The number of threads to use for checking chunk existence (default 2)
-  --chunk-load-ahead int
-    	The number of chunks that should be read ahead (default 3)
-  --chunk-load-threads int
-    	The number of threads to use for downloading chunks (default 2)
-  --chunk-size string
-    	The size of each chunk that is downloaded (units: B, K, M, G) (default "10M")
-  -c, --config string
-    	The path to the configuration directory (default "~/.plexdrive")
-  --drive-id string
-    	The ID of the shared drive to mount (including team drives)
-  -o, --fuse-options string
-    	Fuse mount options (e.g. -fuse-options allow_other,...)
-  --gid int
-    	Set the mounts GID (-1 = default permissions) (default -1)
-  --max-chunks int
-    	The maximum number of chunks to be stored in memory (default 10)
-  --refresh-interval duration
-    	The time to wait till checking for changes (default 1m0s)
-  --root-node-id string
-    	The ID of the root node to mount (use this for only mount a sub directory) (default "root")
-  --uid int
-    	Set the mounts UID (-1 = default permissions) (default -1)
-  --umask value
-    	Override the default file permissions
-  -v, --verbosity int
-    	Set the log level (0 = error, 1 = warn, 2 = info, 3 = debug, 4 = trace)
-  --version
-    	Displays program's version information
+      --acknowledge-abuse           Allows files identified as abusive (malware, etc.) to be downloaded in Drive
+      --cache-file string           Path of the cache file, defaults to cache.bolt in the configuration directory
+      --chunk-check-threads int     The number of threads to use for checking chunk existence (default 6)
+      --chunk-load-ahead int        The number of chunks that should be read ahead (default 11)
+      --chunk-load-threads int      The number of threads to use for downloading chunks (default 6)
+      --chunk-size string           The size of each chunk that is downloaded (units: B, K, M, G) (default "10M")
+  -c, --config string               The path to the configuration directory (default "~/.plexdrive")
+      --drive-id string             The ID of the shared drive to mount (including team drives)
+  -o, --fuse-options string         Fuse mount options (e.g. --fuse-options allow_other,direct_io,...)
+      --gid int                     Set the mounts GID (-1 = default permissions) (default -1)
+      --max-chunks int              The maximum number of chunks to be stored in memory (default 24)
+      --refresh-interval duration   The time to wait till checking for changes (default 1m0s)
+      --root-node-id string         The ID of the root node to mount (use this for only mount a sub directory) (default "root")
+      --uid int                     Set the mounts UID (-1 = default permissions) (default -1)
+      --umask uint32                Override the default file permissions
+  -v, --verbosity int               Set the log level (0 = error, 1 = warn, 2 = info, 3 = debug, 4 = trace)
+      --version                     Displays program's version information
 ```
 
 ### Signals

--- a/chunk/download.go
+++ b/chunk/download.go
@@ -15,12 +15,12 @@ import (
 
 // Downloader handles concurrent chunk downloads
 type Downloader struct {
-	Client           *drive.Client
-	BufferSize       int64
-	queue            chan *Request
-	callbacks        map[string][]DownloadCallback
-	lock             sync.Mutex
-	storage          *Storage
+	Client     *drive.Client
+	BufferSize int64
+	queue      chan *Request
+	callbacks  map[string][]DownloadCallback
+	lock       sync.Mutex
+	storage    *Storage
 }
 
 type DownloadCallback func(error, []byte)
@@ -28,11 +28,11 @@ type DownloadCallback func(error, []byte)
 // NewDownloader creates a new download manager
 func NewDownloader(threads int, client *drive.Client, storage *Storage, bufferSize int64) (*Downloader, error) {
 	manager := Downloader{
-		Client:           client,
-		BufferSize:       bufferSize,
-		queue:            make(chan *Request, 100),
-		callbacks:        make(map[string][]DownloadCallback, 100),
-		storage:          storage,
+		Client:     client,
+		BufferSize: bufferSize,
+		queue:      make(chan *Request, 100),
+		callbacks:  make(map[string][]DownloadCallback, 100),
+		storage:    storage,
 	}
 
 	for i := 0; i < threads; i++ {
@@ -92,10 +92,11 @@ func downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay
 		time.Sleep(time.Duration(delay) * time.Second)
 	}
 
+	downloadURL := request.object.DownloadURL
 	if request.acknowledgeAbuse {
-		request.object.DownloadURL += "&acknowledgeAbuse=true"
+		downloadURL += "&acknowledgeAbuse=true"
 	}
-	req, err := http.NewRequest("GET", request.object.DownloadURL, nil)
+	req, err := http.NewRequest("GET", downloadURL, nil)
 	if nil != err {
 		Log.Debugf("%v", err)
 		return fmt.Errorf("Could not create request object %v (%v) from API", request.object.ObjectID, request.object.Name)

--- a/chunk/download.go
+++ b/chunk/download.go
@@ -92,15 +92,13 @@ func downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay
 		time.Sleep(time.Duration(delay) * time.Second)
 	}
 
+	if request.acknowledgeAbuse {
+		request.object.DownloadURL += "&acknowledgeAbuse=true"
+	}
 	req, err := http.NewRequest("GET", request.object.DownloadURL, nil)
 	if nil != err {
 		Log.Debugf("%v", err)
 		return fmt.Errorf("Could not create request object %v (%v) from API", request.object.ObjectID, request.object.Name)
-	}
-	if request.acknowledgeAbuse {
-		q := req.URL.Query()
-		q.Add("acknowledgeAbuse", "true")
-		req.URL.RawQuery = q.Encode()
 	}
 	req.Header.Add("Range", fmt.Sprintf("bytes=%v-%v", request.offsetStart, request.offsetEnd-1))
 

--- a/chunk/manager.go
+++ b/chunk/manager.go
@@ -8,11 +8,11 @@ import (
 
 // Manager manages chunks on disk
 type Manager struct {
-	ChunkSize  int64
-	LoadAhead  int
-	downloader *Downloader
-	storage    *Storage
-	queue      chan *QueueEntry
+	ChunkSize        int64
+	LoadAhead        int
+	downloader       *Downloader
+	storage          *Storage
+	queue            chan *QueueEntry
 	acknowledgeAbuse bool
 }
 
@@ -62,11 +62,11 @@ func NewManager(chunkSize int64, loadAhead, checkThreads, loadThreads int, clien
 	}
 
 	manager := Manager{
-		ChunkSize:  chunkSize,
-		LoadAhead:  loadAhead,
-		downloader: downloader,
-		storage:    storage,
-		queue:      make(chan *QueueEntry, 100),
+		ChunkSize:        chunkSize,
+		LoadAhead:        loadAhead,
+		downloader:       downloader,
+		storage:          storage,
+		queue:            make(chan *QueueEntry, 100),
 		acknowledgeAbuse: ackAbuse,
 	}
 
@@ -125,14 +125,14 @@ func (m *Manager) requestChunk(object *drive.APIObject, offset, size int64, sequ
 	id := fmt.Sprintf("%v:%v", object.ObjectID, offsetStart)
 
 	request := &Request{
-		id:             id,
-		object:         object,
-		offsetStart:    offsetStart,
-		offsetEnd:      offsetEnd,
-		chunkOffset:    chunkOffset,
-		chunkOffsetEnd: chunkOffset + size,
-		sequence:       sequence,
-		preload:        false,
+		id:               id,
+		object:           object,
+		offsetStart:      offsetStart,
+		offsetEnd:        offsetEnd,
+		chunkOffset:      chunkOffset,
+		chunkOffsetEnd:   chunkOffset + size,
+		sequence:         sequence,
+		preload:          false,
 		acknowledgeAbuse: m.acknowledgeAbuse,
 	}
 

--- a/chunk/manager.go
+++ b/chunk/manager.go
@@ -22,14 +22,15 @@ type QueueEntry struct {
 
 // Request represents a chunk request
 type Request struct {
-	id             string
-	object         *drive.APIObject
-	offsetStart    int64
-	offsetEnd      int64
-	chunkOffset    int64
-	chunkOffsetEnd int64
-	sequence       int
-	preload        bool
+	id               string
+	object           *drive.APIObject
+	offsetStart      int64
+	offsetEnd        int64
+	chunkOffset      int64
+	chunkOffsetEnd   int64
+	sequence         int
+	preload          bool
+	acknowledgeAbuse bool
 }
 
 // Response represetns a chunk response
@@ -40,13 +41,7 @@ type Response struct {
 }
 
 // NewManager creates a new chunk manager
-func NewManager(
-	chunkSize int64,
-	loadAhead,
-	checkThreads int,
-	loadThreads int,
-	client *drive.Client,
-	maxChunks int) (*Manager, error) {
+func NewManager(chunkSize int64, loadAhead, checkThreads, loadThreads int, client *drive.Client, maxChunks int, ackAbuse bool) (*Manager, error) {
 
 	if chunkSize < 4096 {
 		return nil, fmt.Errorf("Chunk size must not be < 4096")
@@ -60,7 +55,7 @@ func NewManager(
 
 	storage := NewStorage(chunkSize, maxChunks)
 
-	downloader, err := NewDownloader(loadThreads, client, storage, chunkSize)
+	downloader, err := NewDownloader(loadThreads, client, storage, chunkSize, ackAbuse)
 	if nil != err {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/claudetech/loggo"
 	. "github.com/claudetech/loggo/default"
-	flag "github.com/spf13/pflag"
 	"github.com/plexdrive/plexdrive/chunk"
 	"github.com/plexdrive/plexdrive/config"
 	"github.com/plexdrive/plexdrive/drive"
 	"github.com/plexdrive/plexdrive/mount"
+	flag "github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
 )
 
@@ -60,6 +60,7 @@ func main() {
 	argUID := flag.Int64("uid", -1, "Set the mounts UID (-1 = default permissions)")
 	argGID := flag.Int64("gid", -1, "Set the mounts GID (-1 = default permissions)")
 	argUmask := flag.Uint32("umask", 0, "Override the default file permissions")
+	argAcknowledgeAbuse := flag.Bool("acknowledge-abuse", false, "Allows files identified as abusive (malware, etc.) to be downloaded in Drive")
 	// argDownloadSpeedLimit := flag.String("speed-limit", "", "This value limits the download speed, e.g. 5M = 5MB/s per chunk (units: B, K, M, G)")
 	flag.Parse()
 
@@ -139,6 +140,7 @@ func main() {
 		Log.Debugf("UID                  : %v", uid)
 		Log.Debugf("GID                  : %v", gid)
 		Log.Debugf("umask                : %v", umask)
+		Log.Debugf("acknowledge-abuse    : %v", argAcknowledgeAbuse)
 		// Log.Debugf("speed-limit          : %v", *argDownloadSpeedLimit)
 		// version missing here
 
@@ -192,7 +194,8 @@ func main() {
 			*argChunkCheckThreads,
 			*argChunkLoadThreads,
 			client,
-			*argMaxChunks)
+			*argMaxChunks,
+			*argAcknowledgeAbuse)
 		if nil != err {
 			Log.Errorf("%v", err)
 			os.Exit(4)


### PR DESCRIPTION
This resolves #399 via an additional `--acknowledge-abuse` flag.  Right off the bat, I totally understand if this isn't a desired feature: the comment in #399 was ambiguous if it's desired.  If you don't want it, feel free to close.

The implementation itself is straightforward and comes from [the documentation](https://developers.google.com/drive/api/v3/manage-downloads).  I've briefly tested it and confirm the flag is sent, but I don't have any setup affected by the bug so can't confirm the fix.