### PR TITLE
MMap based chunk cache and disk based caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ You can use [this tutorial](TUTORIAL.md) for instruction how to mount an encrypt
 Usage of ./plexdrive mount:
       --acknowledge-abuse           Allows files identified as abusive (malware, etc.) to be downloaded in Drive
       --cache-file string           Path of the cache file, defaults to cache.bolt in the configuration directory
+      --chunk-file                  Path of the chunk cache file, defaults to chunks.dat in the configuration directory
+      --chunk-disk-cache            Enable disk based chunk cache to --chunk-file, defaults to cache chunks in memory
       --chunk-check-threads int     The number of threads to use for checking chunk existence (default 6)
       --chunk-load-ahead int        The number of chunks that should be read ahead (default 11)
       --chunk-load-threads int      The number of threads to use for downloading chunks (default 6)

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -1,0 +1,54 @@
+package chunk
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+)
+
+// Chunk of memory
+type Chunk struct {
+	clean  bool
+	header []byte
+	bytes  []byte
+}
+
+func (c *Chunk) ID() uint64 {
+	return binary.LittleEndian.Uint64(c.header[0:])
+}
+
+func (c *Chunk) Size() uint32 {
+	return binary.LittleEndian.Uint32(c.header[8:])
+}
+
+func (c *Chunk) Checksum() uint32 {
+	return binary.LittleEndian.Uint32(c.header[12:])
+}
+
+func (c *Chunk) Valid(id uint64) bool {
+	if !c.clean {
+		c.clean = c.Checksum() == c.calculateChecksum()
+	}
+	return c.clean
+}
+
+func (c *Chunk) Update(id uint64, bytes []byte) {
+	binary.LittleEndian.PutUint64(c.header[0:], id)
+	size := uint32(copy(c.bytes, bytes))
+	binary.LittleEndian.PutUint32(c.header[8:], size)
+	checksum := c.calculateChecksum()
+	binary.LittleEndian.PutUint32(c.header[12:], checksum)
+	c.clean = true
+}
+
+func (c *Chunk) calculateChecksum() uint32 {
+	size := c.Size()
+	if nil == c.bytes || 0 == size {
+		return 0
+	}
+	if maxSize := uint32(len(c.bytes)); size > maxSize {
+		// corrupt size or truncated chunk, fix size
+		binary.LittleEndian.PutUint32(c.header[8:], maxSize)
+		return crc32.Checksum(c.bytes, crc32Table)
+	}
+	return crc32.Checksum(c.bytes[:size], crc32Table)
+}

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -1,6 +1,7 @@
 package chunk
 
 import (
+	"container/list"
 	"encoding/binary"
 	"hash/crc32"
 )
@@ -10,6 +11,7 @@ type Chunk struct {
 	clean  bool
 	header []byte
 	bytes  []byte
+	item   *list.Element
 }
 
 func (c *Chunk) ID() uint64 {

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -28,6 +28,14 @@ func (c *Chunk) Checksum() uint32 {
 
 func (c *Chunk) Valid(id uint64) bool {
 	if !c.clean {
+		checksum := c.Checksum()
+		size := c.Size()
+		// check and swap older chunk metadata
+		byteSize := uint32(len(c.bytes))
+		if size != byteSize && byteSize == checksum {
+			binary.LittleEndian.PutUint32(c.header[8:], checksum)
+			binary.LittleEndian.PutUint32(c.header[12:], size)
+		}
 		c.clean = c.Checksum() == c.calculateChecksum()
 	}
 	return c.clean

--- a/chunk/download.go
+++ b/chunk/download.go
@@ -18,7 +18,7 @@ type Downloader struct {
 	Client     *drive.Client
 	BufferSize int64
 	queue      chan *Request
-	callbacks  map[string][]DownloadCallback
+	callbacks  map[RequestID][]DownloadCallback
 	lock       sync.Mutex
 	storage    *Storage
 }
@@ -31,7 +31,7 @@ func NewDownloader(threads int, client *drive.Client, storage *Storage, bufferSi
 		Client:     client,
 		BufferSize: bufferSize,
 		queue:      make(chan *Request, 100),
-		callbacks:  make(map[string][]DownloadCallback, 100),
+		callbacks:  make(map[RequestID][]DownloadCallback, 100),
 		storage:    storage,
 	}
 

--- a/chunk/stack.go
+++ b/chunk/stack.go
@@ -8,8 +8,7 @@ import (
 // Stack is a thread safe list/stack implementation
 type Stack struct {
 	items   *list.List
-	index   map[string]*list.Element
-	len     int
+	index   map[int]*list.Element
 	lock    sync.Mutex
 	maxSize int
 }
@@ -18,27 +17,33 @@ type Stack struct {
 func NewStack(maxChunks int) *Stack {
 	return &Stack{
 		items:   list.New(),
-		index:   make(map[string]*list.Element, maxChunks),
+		index:   make(map[int]*list.Element, maxChunks),
 		maxSize: maxChunks,
 	}
 }
 
-// Pop pops the first item from the stack
-func (s *Stack) Pop() string {
+// Len gets the number of items on the stack
+func (s *Stack) Len() int {
 	s.lock.Lock()
-	if s.len < s.maxSize {
+	defer s.lock.Unlock()
+	return s.items.Len()
+}
+
+// Pop pops the first item from the stack
+func (s *Stack) Pop() int {
+	s.lock.Lock()
+	if s.items.Len() < s.maxSize {
 		s.lock.Unlock()
-		return ""
+		return -1
 	}
 
 	item := s.items.Front()
 	if nil == item {
 		s.lock.Unlock()
-		return ""
+		return -1
 	}
 	s.items.Remove(item)
-	s.len--
-	id := item.Value.(string)
+	id := item.Value.(int)
 	delete(s.index, id)
 	s.lock.Unlock()
 
@@ -46,24 +51,42 @@ func (s *Stack) Pop() string {
 }
 
 // Touch moves the specified item to the last position of the stack
-func (s *Stack) Touch(id string) {
+func (s *Stack) Touch(id int) {
 	s.lock.Lock()
 	item, exists := s.index[id]
-	if exists {
+	if exists && item != s.items.Back() {
 		s.items.MoveToBack(item)
 	}
 	s.lock.Unlock()
 }
 
 // Push adds a new item to the last position of the stack
-func (s *Stack) Push(id string) {
+func (s *Stack) Push(id int) {
 	s.lock.Lock()
+	defer s.lock.Unlock()
 	if _, exists := s.index[id]; exists {
-		s.lock.Unlock()
 		return
 	}
-	s.items.PushBack(id)
-	s.index[id] = s.items.Back()
-	s.len++
-	s.lock.Unlock()
+	s.index[id] = s.items.PushBack(id)
+}
+
+// Prepend adds a list to the front of the stack
+func (s *Stack) Prepend(items *list.List) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	for item := items.Front(); item != nil; item = item.Next() {
+		id := item.Value.(int)
+		s.index[id] = item
+	}
+	s.items.PushFrontList(items)
+}
+
+// Purge an item from the stack
+func (s *Stack) Purge(id int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	item, exists := s.index[id]
+	if exists && item != s.items.Front() {
+		s.items.MoveToFront(item)
+	}
 }

--- a/chunk/stack.go
+++ b/chunk/stack.go
@@ -8,7 +8,6 @@ import (
 // Stack is a thread safe list/stack implementation
 type Stack struct {
 	items   *list.List
-	index   map[int]*list.Element
 	lock    sync.Mutex
 	maxSize int
 }
@@ -17,7 +16,6 @@ type Stack struct {
 func NewStack(maxChunks int) *Stack {
 	return &Stack{
 		items:   list.New(),
-		index:   make(map[int]*list.Element, maxChunks),
 		maxSize: maxChunks,
 	}
 }
@@ -32,61 +30,46 @@ func (s *Stack) Len() int {
 // Pop pops the first item from the stack
 func (s *Stack) Pop() int {
 	s.lock.Lock()
+	defer s.lock.Unlock()
 	if s.items.Len() < s.maxSize {
-		s.lock.Unlock()
 		return -1
 	}
-
 	item := s.items.Front()
 	if nil == item {
-		s.lock.Unlock()
 		return -1
 	}
 	s.items.Remove(item)
-	id := item.Value.(int)
-	delete(s.index, id)
-	s.lock.Unlock()
-
-	return id
+	return item.Value.(int)
 }
 
 // Touch moves the specified item to the last position of the stack
-func (s *Stack) Touch(id int) {
+func (s *Stack) Touch(item *list.Element) {
 	s.lock.Lock()
-	item, exists := s.index[id]
-	if exists && item != s.items.Back() {
+	if item != s.items.Back() {
 		s.items.MoveToBack(item)
 	}
 	s.lock.Unlock()
 }
 
 // Push adds a new item to the last position of the stack
-func (s *Stack) Push(id int) {
+func (s *Stack) Push(id int) *list.Element {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	if _, exists := s.index[id]; exists {
-		return
-	}
-	s.index[id] = s.items.PushBack(id)
+	return s.items.PushBack(id)
 }
 
 // Prepend adds a list to the front of the stack
 func (s *Stack) Prepend(items *list.List) {
 	s.lock.Lock()
-	defer s.lock.Unlock()
-	for item := items.Front(); item != nil; item = item.Next() {
-		id := item.Value.(int)
-		s.index[id] = item
-	}
 	s.items.PushFrontList(items)
+	s.lock.Unlock()
 }
 
 // Purge an item from the stack
-func (s *Stack) Purge(id int) {
+func (s *Stack) Purge(item *list.Element) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	item, exists := s.index[id]
-	if exists && item != s.items.Front() {
+	if item != s.items.Front() {
 		s.items.MoveToFront(item)
 	}
 }

--- a/chunk/stack_test.go
+++ b/chunk/stack_test.go
@@ -5,43 +5,67 @@ import "testing"
 func TestOOB(t *testing.T) {
 	stack := NewStack(1)
 
-	stack.Push("1")
-	stack.Touch("1")
+	stack.Push(1)
+	stack.Touch(1)
 }
 
 func TestAddToStack(t *testing.T) {
 	stack := NewStack(1)
 
-	stack.Push("1")
-	stack.Push("2")
-	stack.Push("3")
-	stack.Push("4")
+	stack.Push(1)
+	stack.Push(2)
+	stack.Push(3)
+	stack.Push(4)
 
-	stack.Touch("1")
-	stack.Touch("3")
+	stack.Touch(1)
+	stack.Touch(3)
+
+	stack.Purge(4)
 
 	v := stack.Pop()
-	if "2" != v {
-		t.Fatalf("Expected 2 got %v", v)
-	}
-
-	v = stack.Pop()
-	if "4" != v {
+	if 4 != v {
 		t.Fatalf("Expected 4 got %v", v)
 	}
 
 	v = stack.Pop()
-	if "1" != v {
+	if 2 != v {
+		t.Fatalf("Expected 2 got %v", v)
+	}
+
+	v = stack.Pop()
+	if 1 != v {
 		t.Fatalf("Expected 1 got %v", v)
 	}
 
 	v = stack.Pop()
-	if "3" != v {
+	if 3 != v {
 		t.Fatalf("Expected 3 got %v", v)
 	}
 
 	v = stack.Pop()
-	if "" != v {
-		t.Fatalf("Expected nil got %v", v)
+	if -1 != v {
+		t.Fatalf("Expected -1 got %v", v)
 	}
+}
+
+func TestLen(t *testing.T) {
+	stack := NewStack(1)
+
+	v := stack.Len()
+	if 0 != v {
+		t.Fatalf("Expected 0 got %v", v)
+	}
+
+	stack.Push(1)
+	v = stack.Len()
+	if 1 != v {
+		t.Fatalf("Expected 1 got %v", v)
+	}
+
+	_ = stack.Pop()
+	v = stack.Len()
+	if 0 != v {
+		t.Fatalf("Expected 0 got %v", v)
+	}
+
 }

--- a/chunk/stack_test.go
+++ b/chunk/stack_test.go
@@ -5,22 +5,23 @@ import "testing"
 func TestOOB(t *testing.T) {
 	stack := NewStack(1)
 
-	stack.Push(1)
-	stack.Touch(1)
+	item := stack.Push(1)
+	stack.Touch(item)
 }
 
 func TestAddToStack(t *testing.T) {
 	stack := NewStack(1)
 
-	stack.Push(1)
-	stack.Push(2)
-	stack.Push(3)
-	stack.Push(4)
+	item1 := stack.Push(1)
+	item2 := stack.Push(2)
+	item3 := stack.Push(3)
+	item4 := stack.Push(4)
 
-	stack.Touch(1)
-	stack.Touch(3)
+	stack.Touch(item1)
+	stack.Touch(item3)
 
-	stack.Purge(4)
+	stack.Purge(item2)
+	stack.Purge(item4)
 
 	v := stack.Pop()
 	if 4 != v {

--- a/chunk/storage.go
+++ b/chunk/storage.go
@@ -1,8 +1,19 @@
 package chunk
 
 import (
+	"container/list"
+	"encoding/binary"
 	"errors"
+	"fmt"
+	"hash/crc32"
+	"hash/crc64"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
 
 	. "github.com/claudetech/loggo/default"
 )
@@ -10,31 +21,270 @@ import (
 // ErrTimeout is a timeout error
 var ErrTimeout = errors.New("timeout")
 
+var (
+	pageSize   = int64(os.Getpagesize())
+	headerSize = 16
+	tocSize    = int64(16)
+	journalVer = uint8(1)
+	crc32Table = crc32.MakeTable(crc32.Castagnoli)
+	crc64Table = crc64.MakeTable(crc64.ECMA)
+)
+
 // Storage is a chunk storage
 type Storage struct {
-	ChunkSize int64
-	MaxChunks int
-	chunks    map[string][]byte
-	stack     *Stack
-	lock      sync.RWMutex
-}
-
-// Item represents a chunk in RAM
-type Item struct {
-	id    string
-	bytes []byte
+	ChunkFile  *os.File
+	ChunkSize  int64
+	HeaderSize int64
+	MaxChunks  int
+	chunks     map[uint64]int
+	stack      *Stack
+	lock       sync.RWMutex
+	buffers    []*Chunk
+	loadChunks int
+	lastIndex  int
+	signals    chan os.Signal
+	journal    []byte
 }
 
 // NewStorage creates a new storage
-func NewStorage(chunkSize int64, maxChunks int) *Storage {
-	storage := Storage{
+func NewStorage(chunkSize int64, maxChunks int, chunkFilePath string) (*Storage, error) {
+	s := Storage{
 		ChunkSize: chunkSize,
 		MaxChunks: maxChunks,
-		chunks:    make(map[string][]byte),
+		chunks:    make(map[uint64]int, maxChunks),
 		stack:     NewStack(maxChunks),
+		buffers:   make([]*Chunk, maxChunks, maxChunks),
+		signals:   make(chan os.Signal, 1),
 	}
 
-	return &storage
+	journalSize := tocSize + int64(headerSize*maxChunks)
+	if rem := journalSize % pageSize; 0 != rem {
+		journalSize += pageSize - rem
+	}
+	journalOffset := chunkSize * int64(maxChunks)
+
+	// Non-empty string in chunkFilePath enables MMAP disk storage for chunks
+	if chunkFilePath != "" {
+		chunkFile, err := os.OpenFile(chunkFilePath, os.O_RDWR|os.O_CREATE, 0600)
+		if nil != err {
+			Log.Debugf("%v", err)
+			return nil, fmt.Errorf("Could not open chunk cache file")
+		}
+		stat, err := chunkFile.Stat()
+		if nil != err {
+			Log.Debugf("%v", err)
+			return nil, fmt.Errorf("Could not stat chunk cache file")
+		}
+		s.ChunkFile = chunkFile
+		currentSize := stat.Size()
+		wantedSize := journalOffset + journalSize
+		if currentSize != wantedSize {
+			if currentSize > tocSize {
+				err = s.relocateJournal(currentSize, wantedSize, journalSize, journalOffset)
+				if nil != err {
+					Log.Errorf("%v", err)
+				} else {
+					Log.Infof("Relocated chunk cache journal")
+				}
+			}
+			err = chunkFile.Truncate(wantedSize)
+			if nil != err {
+				Log.Debugf("%v", err)
+				return nil, fmt.Errorf("Could not resize chunk cache file")
+			}
+		}
+		Log.Infof("Created chunk cache file %v", chunkFile.Name())
+		s.loadChunks = int(min(currentSize/chunkSize, int64(maxChunks)))
+	}
+
+	// Alocate journal
+	if journal, err := s.mmap(journalOffset, journalSize); nil != err {
+		return nil, fmt.Errorf("Could not allocate journal: %v", err)
+	} else {
+		unix.Madvise(journal, syscall.MADV_RANDOM)
+		tocOffset := journalSize - tocSize
+		header := journal[tocOffset:]
+		if valid := s.checkJournal(header, false); !valid {
+			s.initJournal(header)
+		}
+		s.journal = journal[:tocOffset]
+	}
+
+	// Setup sighandler
+	signal.Notify(s.signals, syscall.SIGINT, syscall.SIGTERM)
+
+	// Initialize chunks
+	if err := s.mmapChunks(); nil != err {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+// relocateJournal moves existing journal prior to resize
+func (s *Storage) relocateJournal(currentSize, wantedSize, journalSize, journalOffset int64) error {
+	header := make([]byte, tocSize, tocSize)
+	if _, err := s.ChunkFile.ReadAt(header, currentSize-tocSize); nil != err {
+		return fmt.Errorf("Failed to read journal header: %v", err)
+	}
+
+	if valid := s.checkJournal(header, true); !valid {
+		return fmt.Errorf("Failed to validate journal header")
+	}
+
+	oldMaxChunks := int64(binary.LittleEndian.Uint32(header[4:]))
+	oldJournalOffset := s.ChunkSize * int64(oldMaxChunks)
+	oldJournalSize := min(journalSize, currentSize-oldJournalOffset) - tocSize
+	journal := make([]byte, journalSize, journalSize)
+
+	if _, err := s.ChunkFile.ReadAt(journal[:oldJournalSize], oldJournalOffset); nil != err {
+		return fmt.Errorf("Failed to read journal: %v", err)
+	}
+
+	s.initJournal(header)
+
+	if err := s.ChunkFile.Truncate(currentSize - oldJournalSize - tocSize); nil != err {
+		return fmt.Errorf("Could not truncate chunk cache journal: %v", err)
+	}
+
+	if err := s.ChunkFile.Truncate(wantedSize); nil != err {
+		return fmt.Errorf("Could not resize chunk cache file: %v", err)
+	}
+
+	if _, err := s.ChunkFile.WriteAt(journal, journalOffset); nil != err {
+		return fmt.Errorf("Failed to write journal: %v", err)
+	}
+	if _, err := s.ChunkFile.WriteAt(header, wantedSize-tocSize); nil != err {
+		return fmt.Errorf("Failed to write journal header: %v", err)
+	}
+	return nil
+}
+
+// checkJournal verifies the journal header
+func (s *Storage) checkJournal(journal []byte, skipMaxChunks bool) bool {
+	// check magic bytes
+	if journal[0] != 'P' || journal[1] != 'D' {
+		return false
+	}
+	version := uint8(journal[2])
+	checksum := binary.LittleEndian.Uint32(journal[12:])
+	if 0 == version || 0 == checksum {
+		// assume unitialized memory
+		return false
+	}
+	if checksum != crc32.Checksum(journal[:12], crc32Table) {
+		return false
+	}
+	if version != journalVer {
+		return false
+	}
+	header := int(journal[3])
+	if header != headerSize {
+		return false
+	}
+	maxChunks := int(binary.LittleEndian.Uint32(journal[4:]))
+	if !skipMaxChunks && maxChunks != s.MaxChunks {
+		return false
+	}
+	chunkSize := int64(binary.LittleEndian.Uint32(journal[8:]))
+	if chunkSize != s.ChunkSize {
+		return false
+	}
+	return true
+}
+
+// initJournal initializes the journal
+func (s *Storage) initJournal(journal []byte) {
+	journal[0] = 'P'
+	journal[1] = 'D'
+	journal[2] = uint8(journalVer)
+	journal[3] = uint8(headerSize)
+	binary.LittleEndian.PutUint32(journal[4:], uint32(s.MaxChunks))
+	binary.LittleEndian.PutUint32(journal[8:], uint32(s.ChunkSize))
+	checksum := crc32.Checksum(journal[:12], crc32Table)
+	binary.LittleEndian.PutUint32(journal[12:], checksum)
+}
+
+// mmapChunks mmaps buffers and loads chunk metadata
+func (s *Storage) mmapChunks() error {
+	start := time.Now()
+	empty := list.New()
+	restored := list.New()
+	loadedChunks := 0
+	for i := 0; i < s.MaxChunks; i++ {
+		select {
+		case sig := <-s.signals:
+			Log.Warningf("Received signal %v, aborting chunk loader", sig)
+			return fmt.Errorf("Aborted by signal")
+		default:
+			if loaded, err := s.initChunk(i, empty, restored); nil != err {
+				Log.Errorf("Failed to allocate chunk %v: %v", i, err)
+				return fmt.Errorf("Failed to initialize chunks")
+			} else if loaded {
+				loadedChunks++
+			}
+		}
+	}
+	s.stack.Prepend(restored)
+	s.stack.Prepend(empty)
+	elapsed := time.Since(start)
+	if nil != s.ChunkFile {
+		Log.Infof("Loaded %v/%v cache chunks in %v", loadedChunks, s.MaxChunks, elapsed)
+	} else {
+		Log.Infof("Allocated %v cache chunks in %v", s.MaxChunks, elapsed)
+	}
+	return nil
+}
+
+// initChunk tries to restore a chunk from disk
+func (s *Storage) initChunk(index int, empty *list.List, restored *list.List) (bool, error) {
+	chunk, err := s.allocateChunk(index)
+	if err != nil {
+		Log.Debugf("%v", err)
+		return false, err
+	}
+
+	s.buffers[index] = chunk
+
+	id := chunk.ID()
+
+	if id == 0 || index >= s.loadChunks {
+		empty.PushBack(index)
+		Log.Tracef("Allocate chunk %v/%v", index+1, s.MaxChunks)
+		return false, nil
+	}
+
+	restored.PushBack(index)
+	Log.Tracef("Load chunk %v/%v (restored)", index+1, s.MaxChunks)
+	s.chunks[id] = index
+
+	return true, nil
+}
+
+// allocateChunk creates a new mmap-backed chunk
+func (s *Storage) allocateChunk(index int) (*Chunk, error) {
+	Log.Tracef("Mmap chunk %v/%v", index+1, s.MaxChunks)
+	offset := int64(index) * s.ChunkSize
+	bytes, err := s.mmap(offset, s.ChunkSize)
+	if nil != err {
+		return nil, err
+	}
+	unix.Madvise(bytes, syscall.MADV_SEQUENTIAL)
+	headerOffset := index * headerSize
+	header := s.journal[headerOffset : headerOffset+headerSize : headerOffset+headerSize]
+	chunk := Chunk{
+		header: header,
+		bytes:  bytes,
+	}
+	return &chunk, nil
+}
+
+func (s *Storage) mmap(offset, size int64) ([]byte, error) {
+	if s.ChunkFile != nil {
+		return unix.Mmap(int(s.ChunkFile.Fd()), offset, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	} else {
+		return unix.Mmap(-1, 0, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	}
 }
 
 // Clear removes all old chunks on disk (will be called on each program start)
@@ -43,46 +293,90 @@ func (s *Storage) Clear() error {
 }
 
 // Load a chunk from ram or creates it
-func (s *Storage) Load(id string) []byte {
+func (s *Storage) Load(key string) []byte {
+	id := keyToId(key)
 	s.lock.RLock()
-	if chunk, exists := s.chunks[id]; exists {
-		s.stack.Touch(id)
+	chunk, index := s.fetch(id)
+	if nil == chunk {
+		Log.Tracef("Load chunk %v (missing)", key)
 		s.lock.RUnlock()
-		return chunk
+		return nil
+	}
+	if chunk.clean {
+		Log.Tracef("Load chunk %v (clean)", key)
+		defer s.lock.RUnlock()
+		return chunk.bytes
 	}
 	s.lock.RUnlock()
+	// Switch to write lock to avoid races on crc verification
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if chunk.Valid(id) {
+		Log.Debugf("Load chunk %v (verified)", key)
+		return chunk.bytes
+	}
+	Log.Warningf("Load chunk %v (bad checksum: %08x <> %08x)", key, chunk.Checksum(), chunk.calculateChecksum())
+	s.stack.Purge(index)
 	return nil
 }
 
 // Store stores a chunk in the RAM and adds it to the disk storage queue
-func (s *Storage) Store(id string, bytes []byte) error {
+func (s *Storage) Store(key string, bytes []byte) (err error) {
+	id := keyToId(key)
 	s.lock.RLock()
 
-	if _, exists := s.chunks[id]; exists {
-		s.stack.Touch(id)
+	// Avoid storing same chunk multiple times
+	chunk, index := s.fetch(id)
+	if nil != chunk && chunk.clean {
+		Log.Tracef("Create chunk %v (exists: clean)", key)
 		s.lock.RUnlock()
 		return nil
 	}
 
 	s.lock.RUnlock()
 	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	var chunk []byte
-	deleteID := s.stack.Pop()
-	if "" != deleteID {
-		chunk = s.chunks[deleteID]
-		delete(s.chunks, deleteID)
-
-		Log.Debugf("Deleted chunk %v", deleteID)
+	if nil != chunk {
+		if chunk.Valid(id) {
+			Log.Debugf("Create chunk %v (exists: valid)", key)
+			return nil
+		}
+		Log.Warningf("Create chunk %v(exists: overwrite)", key)
 	} else {
-		chunk = make([]byte, s.ChunkSize)
+		index = s.stack.Pop()
+		if -1 == index {
+			Log.Debugf("Create chunk %v (failed)", key)
+			return fmt.Errorf("No buffers available")
+		}
+		chunk = s.buffers[index]
+		deleteID := chunk.ID()
+		if 0 != deleteID {
+			delete(s.chunks, deleteID)
+			Log.Debugf("Create chunk %v (reused)", key)
+		} else {
+			Log.Debugf("Create chunk %v (stored)", key)
+		}
+		s.chunks[id] = index
+		s.stack.Push(index)
 	}
 
-	copy(chunk, bytes)
-	s.chunks[id] = chunk
-	s.stack.Push(id)
-
-	s.lock.Unlock()
+	chunk.Update(id, bytes)
 
 	return nil
+}
+
+// fetch chunk and index by id
+func (s *Storage) fetch(id uint64) (*Chunk, int) {
+	index, exists := s.chunks[id]
+	if !exists {
+		return nil, -1
+	}
+	s.stack.Touch(index)
+	return s.buffers[index], index
+}
+
+// keyToId converts string key to internal uint64 representation
+func keyToId(key string) uint64 {
+	return crc64.Checksum([]byte(key), crc64Table)
 }

--- a/chunk/storage.go
+++ b/chunk/storage.go
@@ -175,27 +175,31 @@ func (s *Storage) checkJournal(journal []byte, skipMaxChunks bool) bool {
 	h := (*journalHeader)(unsafe.Pointer(&journal[0]))
 	// check magic bytes / endianess mismatch ('PD' vs 'DP')
 	if h.magic != journalMagic {
+		Log.Debugf("Journal magic mismatch: %v != %v", h.magic, journalMagic)
 		return false
 	}
-	if 0 == h.version || 0 == h.checksum {
-		// assume unitialized memory
-		return false
-	}
-	if h.checksum != crc32.Checksum(journal[:12], crc32Table) {
+	checksum := crc32.Checksum(journal[:12], crc32Table)
+	if h.checksum != checksum {
+		Log.Debugf("Journal checksum mismatch: %08X != %08X", h.checksum, checksum)
 		return false
 	}
 	if h.version != journalVersion {
+		Log.Debugf("Journal version mismatch: %v != %v", h.version, journalVersion)
 		return false
 	}
 	if h.headerSize != uint8(headerSize) {
+		Log.Debugf("Journal chunk header size mismatch: %v != %v", h.headerSize, headerSize)
 		return false
 	}
 	if !skipMaxChunks && h.maxChunks != uint32(s.MaxChunks) {
+		Log.Debugf("Journal max chunks mismatch: %v != %v", h.maxChunks, s.MaxChunks)
 		return false
 	}
 	if h.chunkSize != uint32(s.ChunkSize) {
+		Log.Debugf("Journal chunk size mismatch: %v != %v", h.chunkSize, s.ChunkSize)
 		return false
 	}
+	Log.Debug("Journal is valid")
 	return true
 }
 

--- a/chunk/storage.go
+++ b/chunk/storage.go
@@ -25,7 +25,6 @@ const (
 
 var (
 	blankRequestID RequestID
-	pageSize       = int64(os.Getpagesize())
 	crc32Table     = crc32.MakeTable(crc32.Castagnoli)
 )
 
@@ -68,9 +67,6 @@ func NewStorage(chunkSize int64, maxChunks int, maxMmapSize int64, chunkFilePath
 	}
 
 	journalSize := tocSize + int64(headerSize*maxChunks)
-	if rem := journalSize % pageSize; 0 != rem {
-		journalSize += pageSize - rem
-	}
 	journalOffset := chunkSize * int64(maxChunks)
 
 	// Non-empty string in chunkFilePath enables MMAP disk storage for chunks

--- a/drive/cache.go
+++ b/drive/cache.go
@@ -38,6 +38,7 @@ type APIObject struct {
 	Parents      []string
 	CanTrash     bool
 	MD5Checksum  string
+	RevisionID   string
 }
 
 // PageToken is the last change id

--- a/drive/cache.go
+++ b/drive/cache.go
@@ -37,6 +37,7 @@ type APIObject struct {
 	DownloadURL  string
 	Parents      []string
 	CanTrash     bool
+	MD5Checksum  string
 }
 
 // PageToken is the last change id

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -19,7 +19,7 @@ import (
 )
 
 // fields are the fields that should be returned by the Google Drive API
-const fields = "id, name, mimeType, modifiedTime, size, explicitlyTrashed, parents, capabilities/canTrash, shortcutDetails"
+const fields = "id, name, mimeType, modifiedTime, md5Checksum, size, explicitlyTrashed, parents, capabilities/canTrash, shortcutDetails"
 
 // folderMimeType is the mime type of a Google Drive folder
 const folderMimeType = "application/vnd.google-apps.folder"
@@ -443,5 +443,6 @@ func (d *Client) mapFileToObject(file *gdrive.File) (*APIObject, error) {
 		DownloadURL:  fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%v?alt=media", targetFile.Id),
 		Parents:      parents,
 		CanTrash:     file.Capabilities.CanTrash,
+		MD5Checksum:  targetFile.Md5Checksum,
 	}, err
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
 	argCacheFile := flag.String("cache-file", filepath.Join(*argConfigPath, "cache.bolt"), "Path of the cache file")
 	argChunkFile := flag.String("chunk-file", filepath.Join(*argConfigPath, "chunks.dat"), "Path of the chunk cache file")
-	argChunkDiskCache := flag.Bool("chunk-disk-cache", false, "Enable disk based chunk cache")
+	argChunkDiskCache := flag.Bool("chunk-disk-cache", false, "Enable disk based chunk cache to --chunk-file")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
 	argChunkCheckThreads := flag.Int("chunk-check-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for checking chunk existence")

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
 	argCacheFile := flag.String("cache-file", filepath.Join(*argConfigPath, "cache.bolt"), "Path of the cache file")
 	argChunkFile := flag.String("chunk-file", filepath.Join(*argConfigPath, "chunks.dat"), "Path of the chunk cache file")
-	argChunkMmap := flag.Bool("chunk-mmap", false, "Enable disk based chunk cache")
+	argChunkDiskCache := flag.Bool("chunk-disk-cache", false, "Enable disk based chunk cache")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
 	argChunkCheckThreads := flag.Int("chunk-check-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for checking chunk existence")
@@ -127,7 +127,7 @@ func main() {
 		Log.Debugf("config               : %v", *argConfigPath)
 		Log.Debugf("cache-file           : %v", *argCacheFile)
 		Log.Debugf("chunk-file           : %v", *argChunkFile)
-		Log.Debugf("chunk-mmap           : %v", *argChunkMmap)
+		Log.Debugf("chunk-disk-cache     : %v", *argChunkDiskCache)
 		Log.Debugf("chunk-size           : %v", *argChunkSize)
 		Log.Debugf("chunk-load-threads   : %v", *argChunkLoadThreads)
 		Log.Debugf("chunk-check-threads  : %v", *argChunkCheckThreads)
@@ -153,7 +153,7 @@ func main() {
 			Log.Debugf("%v", err)
 			os.Exit(1)
 		}
-		if *argChunkMmap {
+		if *argChunkDiskCache {
 			if err := os.MkdirAll(filepath.Dir(*argChunkFile), 0766); nil != err {
 				Log.Errorf("Could not create chunk cache file directory")
 				Log.Debugf("%v", err)
@@ -195,7 +195,7 @@ func main() {
 			os.Exit(4)
 		}
 
-		if *argChunkMmap != true {
+		if *argChunkDiskCache != true {
 			*argChunkFile = ""
 		}
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,8 @@ func main() {
 	argDriveID := flag.String("drive-id", "", "The ID of the shared drive to mount (including team drives)")
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
 	argCacheFile := flag.String("cache-file", filepath.Join(*argConfigPath, "cache.bolt"), "Path of the cache file")
+	argChunkFile := flag.String("chunk-file", filepath.Join(*argConfigPath, "chunks.dat"), "Path of the chunk cache file")
+	argChunkMmap := flag.Bool("chunk-mmap", false, "Enable disk based chunk cache")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
 	argChunkCheckThreads := flag.Int("chunk-check-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for checking chunk existence")
@@ -124,6 +126,8 @@ func main() {
 		Log.Debugf("drive-id             : %v", *argDriveID)
 		Log.Debugf("config               : %v", *argConfigPath)
 		Log.Debugf("cache-file           : %v", *argCacheFile)
+		Log.Debugf("chunk-file           : %v", *argChunkFile)
+		Log.Debugf("chunk-mmap           : %v", *argChunkMmap)
 		Log.Debugf("chunk-size           : %v", *argChunkSize)
 		Log.Debugf("chunk-load-threads   : %v", *argChunkLoadThreads)
 		Log.Debugf("chunk-check-threads  : %v", *argChunkCheckThreads)
@@ -148,6 +152,15 @@ func main() {
 			Log.Errorf("Could not create cache file directory")
 			Log.Debugf("%v", err)
 			os.Exit(1)
+		}
+		if *argChunkMmap {
+			if err := os.MkdirAll(filepath.Dir(*argChunkFile), 0766); nil != err {
+				Log.Errorf("Could not create chunk cache file directory")
+				Log.Debugf("%v", err)
+				os.Exit(1)
+			}
+		} else {
+			*argChunkFile = ""
 		}
 
 		// set the global buffer configuration
@@ -182,7 +195,12 @@ func main() {
 			os.Exit(4)
 		}
 
+		if *argChunkMmap != true {
+			*argChunkFile = ""
+		}
+
 		chunkManager, err := chunk.NewManager(
+			*argChunkFile,
 			chunkSize,
 			*argChunkLoadAhead,
 			*argChunkCheckThreads,

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	argRootNodeID := flag.String("root-node-id", "root", "The ID of the root node to mount (use this for only mount a sub directory)")
 	argDriveID := flag.String("drive-id", "", "The ID of the shared drive to mount (including team drives)")
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
-	argCacheFile := flag.String("cache-file", "", "Path of the cache file, defaults to cache.bolt in the configuration directory")
+	argCacheFile := flag.String("cache-file", filepath.Join(*argConfigPath, "cache.bolt"), "Path of the cache file")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
 	argChunkCheckThreads := flag.Int("chunk-check-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for checking chunk existence")
@@ -79,12 +79,6 @@ func main() {
 			flag.Usage()
 			fmt.Println()
 			panic(fmt.Errorf("Mountpoint not specified"))
-		}
-
-		// build default value for cache-file if it's not passed as flag
-		cacheFilePath := *argCacheFile
-		if !flag.Lookup("cache-file").Changed {
-			cacheFilePath = filepath.Join(*argConfigPath, "cache.bolt")
 		}
 
 		// calculate uid / gid
@@ -129,7 +123,7 @@ func main() {
 		Log.Debugf("root-node-id         : %v", *argRootNodeID)
 		Log.Debugf("drive-id             : %v", *argDriveID)
 		Log.Debugf("config               : %v", *argConfigPath)
-		Log.Debugf("cache-file           : %v", cacheFilePath)
+		Log.Debugf("cache-file           : %v", *argCacheFile)
 		Log.Debugf("chunk-size           : %v", *argChunkSize)
 		Log.Debugf("chunk-load-threads   : %v", *argChunkLoadThreads)
 		Log.Debugf("chunk-check-threads  : %v", *argChunkCheckThreads)
@@ -150,7 +144,7 @@ func main() {
 			Log.Debugf("%v", err)
 			os.Exit(1)
 		}
-		if err := os.MkdirAll(filepath.Dir(cacheFilePath), 0766); nil != err {
+		if err := os.MkdirAll(filepath.Dir(*argCacheFile), 0766); nil != err {
 			Log.Errorf("Could not create cache file directory")
 			Log.Debugf("%v", err)
 			os.Exit(1)
@@ -175,7 +169,7 @@ func main() {
 			}
 		}
 
-		cache, err := drive.NewCache(cacheFilePath, *argConfigPath, *argLogLevel > 3)
+		cache, err := drive.NewCache(*argCacheFile, *argConfigPath, *argLogLevel > 3)
 		if nil != err {
 			Log.Errorf("%v", err)
 			os.Exit(4)


### PR DESCRIPTION
This changes the chunk cache to use MMap for allocating cache chunks.

This significantly reduces plexdrive memory usage, since most allocations bypass the Go garbage collector.

If persistent chunk cache is enabled (`--chunk-disk-cache`), the cache is persisted to the file or device specified by `--chunk-file` (defaults to "chunks.dat" in the config directory).

If no persistent cache is used, plexdrive will use anonymous mmap and will efficiently use the swap file as disk cache, if the size of the chunk cache exceeds the amount of free memory.

The chunk cache uses crc32 to verify the integrity of cache chunks to prevent against corruption, eg. if plexdrive crashes. The checksum will be verified lazily once a cached chunk is loaded.

Another change is that plexdrive now signals changed files to fuse, so it can enable kernel caching of open files. This means that files cached in memory by the kernel can be accessed with nearly no cpu usage by plexdrive.

Since it is possible for files on google drive to change, plexdrive now downloads them using the cached RevisionID of the drive object, which prevents chunks from different versions of the file to be mixed up. So you always get the version that corresponds to the cached metadata in the cache.bolt.

Since additional metadata is stored per file, the `cache.bolt` in the configuration directory should be deleted, when upgrading to this new version of plexdrive.

_The code for this was mostly written two years ago and has been used successfully in production since then. I've rebased the code to the current master and did some quick testing to ensure nothing broke. I've kept the original commits since the sheer number of changes would have been a major effort to compress into more focused commits. So there are quite a few changes that are replaced by later commits in the feature branch._

Resolves #360 