### PR TITLE
Fix cache-file and chunk-file default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can use [this tutorial](TUTORIAL.md) for instruction how to mount an encrypt
 ```
 Usage of ./plexdrive mount:
       --acknowledge-abuse           Allows files identified as abusive (malware, etc.) to be downloaded in Drive
-      --cache-file string           Path of the cache file, defaults to cache.bolt in the configuration directory
-      --chunk-file                  Path of the chunk cache file, defaults to chunks.dat in the configuration directory
+      --cache-file string           Path of the cache file (default "cache.bolt" in configuration directory)
+      --chunk-file string           Path of the chunk cache file (default "chunks.dat" in configuration directory)
       --chunk-disk-cache            Enable disk based chunk cache to --chunk-file, defaults to cache chunks in memory
       --chunk-check-threads int     The number of threads to use for checking chunk existence (default 6)
       --chunk-load-ahead int        The number of chunks that should be read ahead (default 11)

--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func main() {
 	argRootNodeID := flag.String("root-node-id", "root", "The ID of the root node to mount (use this for only mount a sub directory)")
 	argDriveID := flag.String("drive-id", "", "The ID of the shared drive to mount (including team drives)")
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
-	argCacheFile := flag.String("cache-file", filepath.Join(*argConfigPath, "cache.bolt"), "Path of the cache file")
-	argChunkFile := flag.String("chunk-file", filepath.Join(*argConfigPath, "chunks.dat"), "Path of the chunk cache file")
+	argCacheFile := flag.String("cache-file", "", "Path of the cache file (default \"cache.bolt\" in configuration directory)")
+	argChunkFile := flag.String("chunk-file", "", "Path of the chunk cache file (default \"chunks.dat\" in configuration directory)")
 	argChunkDiskCache := flag.Bool("chunk-disk-cache", false, "Enable disk based chunk cache to --chunk-file")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
 	argChunkLoadThreads := flag.Int("chunk-load-threads", max(runtime.NumCPU()/2, 1), "The number of threads to use for downloading chunks")
@@ -83,6 +83,14 @@ func main() {
 			flag.Usage()
 			fmt.Println()
 			panic(fmt.Errorf("Mountpoint not specified"))
+		}
+
+		// set default paths, must happen after parsing to get custom config path
+		if !flag.Lookup("cache-file").Changed {
+			*argCacheFile = filepath.Join(*argConfigPath, "cache.bolt")
+		}
+		if !flag.Lookup("chunk-file").Changed {
+			*argChunkFile = filepath.Join(*argConfigPath, "chunks.dat")
 		}
 
 		// calculate uid / gid


### PR DESCRIPTION
Since `argConfigPath` is only updated after parsing the flags, these paths always used `~/.plexdrive` even if a different config directory was set.

This reimplements #359 that was reverted in #406 and extends it to the new `--chunk-file` option.